### PR TITLE
poc(Engine): test d'extensibilité de ECS avec React

### DIFF
--- a/src/engine/components/AIComponent.ts
+++ b/src/engine/components/AIComponent.ts
@@ -1,0 +1,14 @@
+import { Component } from "../ecs";
+
+export class AIComponent extends Component {
+  type: string;
+  changeDirectionTimer: number;
+  currentDirection: { x: number; y: number };
+  
+  constructor(type: string = "random") {
+    super();
+    this.type = type;
+    this.changeDirectionTimer = 0;
+    this.currentDirection = { x: 0, y: 0 };
+  }
+}

--- a/src/engine/components/MovableComponent.ts
+++ b/src/engine/components/MovableComponent.ts
@@ -1,0 +1,9 @@
+import { Component } from "../ecs";
+
+export class MovableComponent extends Component {
+  speed: number;
+  constructor(speed: number = 5) {
+    super();
+    this.speed = speed;
+  }
+}

--- a/src/engine/components/PositionComponent.ts
+++ b/src/engine/components/PositionComponent.ts
@@ -1,0 +1,11 @@
+import { Component } from "../ecs";
+
+export class PositionComponent extends Component {
+  x: number = 0;
+  y: number = 0;
+  constructor(x: number = 0, y: number = 0) {
+    super();
+    this.x = x;
+    this.y = y;
+  }
+}

--- a/src/engine/components/RenderComponent.ts
+++ b/src/engine/components/RenderComponent.ts
@@ -1,0 +1,11 @@
+import { Component } from "../ecs";
+
+export class RenderComponent extends Component {
+  radius: number;
+  color: string;
+  constructor(radius: number = 20, color: string = "blue") {
+    super();
+    this.radius = radius;
+    this.color = color;
+  }
+}

--- a/src/engine/components/RenderableComponent.ts
+++ b/src/engine/components/RenderableComponent.ts
@@ -1,0 +1,9 @@
+import { Component } from "../ecs";
+
+export class RenderableComponent extends Component {
+  type: string;
+  constructor(type: string) {
+    super();
+    this.type = type;
+  }
+}

--- a/src/engine/components/index.ts
+++ b/src/engine/components/index.ts
@@ -1,0 +1,5 @@
+export { PositionComponent } from "./PositionComponent";
+export { RenderComponent } from "./RenderComponent";
+export { MovableComponent } from "./MovableComponent";
+export { RenderableComponent } from "./RenderableComponent";
+export { AIComponent } from "./AIComponent";

--- a/src/engine/ecs.ts
+++ b/src/engine/ecs.ts
@@ -1,0 +1,104 @@
+export type Entity = number
+
+export abstract class Component { }
+
+export abstract class System {
+    public abstract componentsRequired: Set<Function>
+    public abstract update(entities: Set<Entity>): void
+    public ecs!: ECS
+}
+
+export type ComponentClass<T extends Component> = new (...args: any[]) => T
+
+export class ComponentContainer {
+    private map = new Map<Function, Component>();
+    public add(component: Component): void {
+        this.map.set(component.constructor, component);
+    }
+    public get<T extends Component>(componentClass: ComponentClass<T>): T {
+        return this.map.get(componentClass) as T;
+    }
+    public has(componentClass: Function): boolean {
+        return this.map.has(componentClass);
+    }
+    public hasAll(componentClasses: Iterable<Function>): boolean {
+        for (let cls of componentClasses) {
+            if (!this.map.has(cls)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    public delete(componentClass: Function): void {
+        this.map.delete(componentClass);
+    }
+}
+
+export class ECS {
+    private nextEntityID = 0;
+    private entitiesToDestroy = new Array<Entity>();
+    private entities = new Map<Entity, ComponentContainer>();
+    private systems = new Map<System, Set<Entity>>();
+    public addEntity(): Entity {
+        let entity = this.nextEntityID;
+        this.nextEntityID++;
+        this.entities.set(entity, new ComponentContainer());
+        return entity;
+    }
+    public removeEntity(entity: Entity): void {
+        this.entitiesToDestroy.push(entity);
+    }
+    private destroyEntity(entity: Entity): void {
+        this.entities.delete(entity);
+        for (let entities of this.systems.values()) {
+            entities.delete(entity);  // no-op if doesn't have it
+        }
+    }
+    public addComponent(entity: Entity, component: Component): void {
+        this.entities.get(entity).add(component);
+        this.checkE(entity);
+    }
+    public getComponents(entity: Entity): ComponentContainer {
+        return this.entities.get(entity);
+    }
+    public removeComponent(entity: Entity, componentClass: Function): void {
+        this.entities.get(entity).delete(componentClass);
+        this.checkE(entity);
+    }
+    private checkE(entity: Entity): void {
+        for (let system of this.systems.keys()) {
+            this.checkES(entity, system);
+        }
+    }
+    private checkES(entity: Entity, system: System): void {
+        let have = this.entities.get(entity);
+        let need = system.componentsRequired;
+        if (have.hasAll(need)) {
+            this.systems.get(system).add(entity); // no-op if already has it
+        } else {
+            this.systems.get(system).delete(entity); // no-op if doesn't have it
+        }
+    }
+    public addSystem(system: System): void {
+        if (system.componentsRequired.size == 0) {
+            console.warn("System " + system + " not added: empty components list.")
+            return;
+        }
+        system.ecs = this;
+        this.systems.set(system, new Set());
+        for (let entity of this.entities.keys()) {
+            this.checkES(entity, system);
+        }
+    }
+    public removeSystem(system: System): void {
+        this.systems.delete(system);
+    }
+    public update(): void {
+        for (let [system, entities] of this.systems.entries()) {
+            system.update(entities)
+        }
+        while (this.entitiesToDestroy.length > 0) {
+            this.destroyEntity(this.entitiesToDestroy.pop());
+        }
+    }
+}

--- a/src/engine/systems/AISystem.ts
+++ b/src/engine/systems/AISystem.ts
@@ -1,0 +1,54 @@
+import { System, type Entity } from "../ecs";
+import { PositionComponent, MovableComponent, AIComponent } from "../components";
+
+export class AISystem extends System {
+  public componentsRequired = new Set([PositionComponent, MovableComponent, AIComponent]);
+  private gameAreaWidth = 800;
+  private gameAreaHeight = 600;
+
+  public update(entities: Set<Entity>): void {
+    for (let entity of entities) {
+      const position = this.ecs.getComponents(entity).get(PositionComponent);
+      const movable = this.ecs.getComponents(entity).get(MovableComponent);
+      const ai = this.ecs.getComponents(entity).get(AIComponent);
+
+      if (ai.type === "random") {
+        this.updateRandomMovement(position, movable, ai);
+      }
+    }
+  }
+
+  private updateRandomMovement(position: PositionComponent, movable: MovableComponent, ai: AIComponent): void {
+    // Change direction every 60 frames (roughly 1 second at 60fps)
+    ai.changeDirectionTimer++;
+    
+    if (ai.changeDirectionTimer >= 60) {
+      ai.changeDirectionTimer = 0;
+      // Random direction: -1, 0, or 1 for both x and y
+      ai.currentDirection = {
+        x: Math.floor(Math.random() * 3) - 1, // -1, 0, 1
+        y: Math.floor(Math.random() * 3) - 1, // -1, 0, 1
+      };
+    }
+
+    // Apply movement
+    const newX = position.x + (ai.currentDirection.x * movable.speed);
+    const newY = position.y + (ai.currentDirection.y * movable.speed);
+
+    // Keep enemy within bounds (with some margin for radius)
+    const margin = 25;
+    if (newX >= margin && newX <= this.gameAreaWidth - margin) {
+      position.x = newX;
+    } else {
+      // Reverse direction if hitting boundary
+      ai.currentDirection.x *= -1;
+    }
+
+    if (newY >= margin && newY <= this.gameAreaHeight - margin) {
+      position.y = newY;
+    } else {
+      // Reverse direction if hitting boundary
+      ai.currentDirection.y *= -1;
+    }
+  }
+}

--- a/src/engine/systems/ColorChangeSystem.ts
+++ b/src/engine/systems/ColorChangeSystem.ts
@@ -1,0 +1,36 @@
+import { System, type Entity } from "../ecs";
+import { RenderComponent } from "../components";
+import { type InputState } from "./InputState";
+
+export class ColorChangeSystem extends System {
+  public componentsRequired = new Set([RenderComponent]);
+  private inputState: InputState = { up: false, down: false, left: false, right: false, space: false };
+  private spaceWasPressed = false;
+  private colors = ["blue", "red", "green", "yellow", "purple", "orange"];
+  private currentColorIndex = 0;
+
+  public setInputState(inputState: InputState): void {
+    const spaceJustPressed = inputState.space && !this.spaceWasPressed;
+    
+    if (spaceJustPressed) {
+      this.currentColorIndex = (this.currentColorIndex + 1) % this.colors.length;
+      this.changeEntityColors();
+    }
+    
+    this.spaceWasPressed = inputState.space;
+    this.inputState = inputState;
+  }
+
+  private changeEntityColors(): void {
+    const newColor = this.colors[this.currentColorIndex];
+    
+    for (let entity of this.ecs.systems.get(this) || new Set()) {
+      const renderComponent = this.ecs.getComponents(entity).get(RenderComponent);
+      renderComponent.color = newColor;
+    }
+  }
+
+  public update(entities: Set<Entity>): void {
+    // Ce système réagit aux inputs, pas au cycle d'update
+  }
+}

--- a/src/engine/systems/InputState.ts
+++ b/src/engine/systems/InputState.ts
@@ -1,0 +1,7 @@
+export type InputState = {
+  up: boolean;
+  down: boolean;
+  left: boolean;
+  right: boolean;
+  space: boolean;
+};

--- a/src/engine/systems/MovementSystem.ts
+++ b/src/engine/systems/MovementSystem.ts
@@ -1,0 +1,32 @@
+import { System, type Entity } from "../ecs";
+import { PositionComponent, MovableComponent } from "../components";
+import { type InputState } from "./InputState";
+
+export class MovementSystem extends System {
+  public componentsRequired = new Set([PositionComponent, MovableComponent]);
+  private inputState: InputState = { up: false, down: false, left: false, right: false, space: false };
+
+  public setInputState(inputState: InputState): void {
+    this.inputState = inputState;
+  }
+
+  public update(entities: Set<Entity>): void {
+    for (let entity of entities) {
+      const position = this.ecs.getComponents(entity).get(PositionComponent);
+      const movable = this.ecs.getComponents(entity).get(MovableComponent);
+
+      if (this.inputState.up) {
+        position.y -= movable.speed;
+      }
+      if (this.inputState.down) {
+        position.y += movable.speed;
+      }
+      if (this.inputState.left) {
+        position.x -= movable.speed;
+      }
+      if (this.inputState.right) {
+        position.x += movable.speed;
+      }
+    }
+  }
+}

--- a/src/engine/systems/RenderSystem.ts
+++ b/src/engine/systems/RenderSystem.ts
@@ -1,0 +1,37 @@
+import { System, type Entity } from "../ecs";
+import { PositionComponent, RenderComponent, RenderableComponent } from "../components";
+
+export type RenderableEntityData = {
+  entity: Entity;
+  type: string;
+  x: number;
+  y: number;
+  radius: number;
+  color: string;
+};
+
+export class RenderSystem extends System {
+  public componentsRequired = new Set([PositionComponent, RenderComponent, RenderableComponent]);
+  public onRenderUpdate: ((entities: Array<RenderableEntityData>) => void) | null = null;
+
+  public update(entities: Set<Entity>): void {
+    if (!this.onRenderUpdate) return;
+
+    const renderData = Array.from(entities).map(entity => {
+      const position = this.ecs.getComponents(entity).get(PositionComponent);
+      const render = this.ecs.getComponents(entity).get(RenderComponent);
+      const renderable = this.ecs.getComponents(entity).get(RenderableComponent);
+      
+      return {
+        entity,
+        type: renderable.type,
+        x: position.x,
+        y: position.y,
+        radius: render.radius,
+        color: render.color
+      };
+    });
+
+    this.onRenderUpdate(renderData);
+  }
+}

--- a/src/engine/systems/index.ts
+++ b/src/engine/systems/index.ts
@@ -1,0 +1,5 @@
+export { MovementSystem } from "./MovementSystem";
+export { RenderSystem, type RenderableEntityData } from "./RenderSystem";
+export { ColorChangeSystem } from "./ColorChangeSystem";
+export { AISystem } from "./AISystem";
+export type { InputState } from "./InputState";

--- a/src/features/john/Playground.tsx
+++ b/src/features/john/Playground.tsx
@@ -1,0 +1,96 @@
+
+import { useEffect, useRef, useState } from "react";
+import { ECS } from "../../engine/ecs";
+import { MovementSystem, RenderSystem, ColorChangeSystem, AISystem, type RenderableEntityData } from "../../engine/systems";
+import { PositionComponent, RenderComponent, MovableComponent, RenderableComponent, AIComponent } from "../../engine/components";
+import { EntityRenderers } from "./entities";
+import { useGameInput } from "./useGameInput";
+
+export const Playground = () => {
+  const ecsRef = useRef<ECS | null>(null);
+  const movementSystemRef = useRef<MovementSystem | null>(null);
+  const colorSystemRef = useRef<ColorChangeSystem | null>(null);
+  const [entities, setEntities] = useState<RenderableEntityData[]>([]);
+  const inputState = useGameInput();
+
+  useEffect(() => {
+    const ecs = new ECS();
+    ecsRef.current = ecs;
+
+    const movementSystem = new MovementSystem();
+    const renderSystem = new RenderSystem();
+    const colorChangeSystem = new ColorChangeSystem();
+    const aiSystem = new AISystem();
+    
+    movementSystemRef.current = movementSystem;
+    colorSystemRef.current = colorChangeSystem;
+    
+    renderSystem.onRenderUpdate = (renderData) => {
+      setEntities([...renderData]);
+    };
+
+    ecs.addSystem(movementSystem);
+    ecs.addSystem(renderSystem);
+    ecs.addSystem(colorChangeSystem);
+    ecs.addSystem(aiSystem);
+
+    const player = ecs.addEntity();
+    ecs.addComponent(player, new PositionComponent(200, 200));
+    ecs.addComponent(player, new RenderComponent(25, "blue"));
+    ecs.addComponent(player, new MovableComponent(3));
+    ecs.addComponent(player, new RenderableComponent("player"));
+
+    // Créer un enemy avec IA
+    const enemy = ecs.addEntity();
+    ecs.addComponent(enemy, new PositionComponent(600, 400));
+    ecs.addComponent(enemy, new RenderComponent(20, "red"));
+    ecs.addComponent(enemy, new MovableComponent(2));
+    ecs.addComponent(enemy, new RenderableComponent("enemy"));
+    ecs.addComponent(enemy, new AIComponent("random"));
+
+    const gameLoop = () => {
+      ecs.update();
+      requestAnimationFrame(gameLoop);
+    };
+    
+    requestAnimationFrame(gameLoop);
+  }, []);
+
+  useEffect(() => {
+    if (movementSystemRef.current) {
+      movementSystemRef.current.setInputState(inputState);
+    }
+    if (colorSystemRef.current) {
+      colorSystemRef.current.setInputState(inputState);
+    }
+  }, [inputState]);
+
+  return (
+    <div style={{position: "relative", width: "100%", height: "100%", display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center" }}>
+      <div>
+        <h4> ZQSD pour bouger, ESPACE pour changer couleur, E pour échanger de couleur</h4>
+      </div>
+      <div style={{position: "relative", width: "800px", height: "600px", border: "1px solid black" }}>
+        {entities.map((entityData) => {
+          const EntityComponent = EntityRenderers[entityData.type as keyof typeof EntityRenderers];
+
+          if (!EntityComponent) {
+            console.warn(`No renderer found for entity type: ${entityData.type}`);
+            return null;
+          }
+
+          return (
+            <EntityComponent
+              key={entityData.entity}
+              entity={entityData.entity}
+              x={entityData.x}
+              y={entityData.y}
+              radius={entityData.radius}
+              color={entityData.color}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/features/john/entities/EnemyEntity.tsx
+++ b/src/features/john/entities/EnemyEntity.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { type Entity } from "../../../engine/ecs";
+
+export type EnemyEntityProps = {
+  entity: Entity;
+  x: number;
+  y: number;
+  radius: number;
+  color: string;
+};
+
+export const EnemyEntity: React.FC<EnemyEntityProps> = ({ entity, x, y, radius, color }) => {
+  return (
+    <div 
+      style={{ 
+        borderRadius: radius,
+        position: "absolute", 
+        top: y - radius,
+        left: x - radius,
+        width: radius * 2, 
+        height: radius * 2, 
+        backgroundColor: color,
+        border: "2px solid darkred",
+        boxShadow: "0 0 10px rgba(255, 0, 0, 0.5)"
+      }}
+      title={`Enemy Entity ${entity}`}
+    >
+      <div style={{
+        position: "absolute",
+        top: "50%",
+        left: "50%",
+        transform: "translate(-50%, -50%)",
+        fontSize: "10px",
+        color: "white",
+        fontWeight: "bold"
+      }}>
+        E
+      </div>
+      <div style={{
+        position: "absolute",
+        top: "30%",
+        left: "30%",
+        width: "6px",
+        height: "6px",
+        backgroundColor: "red",
+        borderRadius: "50%"
+      }} />
+      <div style={{
+        position: "absolute",
+        top: "30%",
+        right: "30%",
+        width: "6px",
+        height: "6px",
+        backgroundColor: "red",
+        borderRadius: "50%"
+      }} />
+    </div>
+  );
+};

--- a/src/features/john/entities/PlayerEntity.tsx
+++ b/src/features/john/entities/PlayerEntity.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { type Entity } from "../../../engine/ecs";
+
+export type PlayerEntityProps = {
+  entity: Entity;
+  x: number;
+  y: number;
+  radius: number;
+  color: string;
+};
+
+export const PlayerEntity: React.FC<PlayerEntityProps> = ({ entity, x, y, radius, color }) => {
+  return (
+    <div 
+      style={{ 
+        borderRadius: radius,
+        position: "absolute", 
+        top: y - radius,
+        left: x - radius,
+        width: radius * 2, 
+        height: radius * 2, 
+        backgroundColor: color,
+        border: "2px solid darkblue"
+      }}
+      title={`Player Entity ${entity}`}
+    >
+      <div style={{
+        position: "absolute",
+        top: "50%",
+        left: "50%",
+        transform: "translate(-50%, -50%)",
+        fontSize: "10px",
+        color: "white",
+        fontWeight: "bold"
+      }}>
+        P
+      </div>
+    </div>
+  );
+};

--- a/src/features/john/entities/index.ts
+++ b/src/features/john/entities/index.ts
@@ -1,0 +1,14 @@
+import { PlayerEntity } from "./PlayerEntity";
+import { EnemyEntity } from "./EnemyEntity";
+
+// Registry des composants React par type d'entité
+export const EntityRenderers = {
+  "player": PlayerEntity,
+  "enemy": EnemyEntity,
+  // "projectile": ProjectileEntity,
+  // etc...
+} as const;
+
+export { PlayerEntity, EnemyEntity };
+
+export type EntityType = keyof typeof EntityRenderers;

--- a/src/features/john/useGameInput.ts
+++ b/src/features/john/useGameInput.ts
@@ -1,0 +1,78 @@
+import { useEffect, useState, useCallback } from "react";
+import { type InputState } from "../../engine/systems/InputState";
+
+export const useGameInput = () => {
+  const [inputState, setInputState] = useState<InputState>({
+    up: false,
+    down: false,
+    left: false,
+    right: false,
+    space: false,
+  });
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    const key = e.key.toLowerCase();
+    setInputState((prev) => {
+      const newState = { ...prev };
+      switch (key) {
+        case 'z':
+        case 'w':
+          newState.up = true;
+          break;
+        case 's':
+          newState.down = true;
+          break;
+        case 'q':
+        case 'a':
+          newState.left = true;
+          break;
+        case 'd':
+          newState.right = true;
+          break;
+        case ' ':
+          newState.space = true;
+          break;
+      }
+      return newState;
+    });
+  }, []);
+
+  const handleKeyUp = useCallback((e: KeyboardEvent) => {
+    const key = e.key.toLowerCase();
+    setInputState((prev) => {
+      const newState = { ...prev };
+      switch (key) {
+        case 'z':
+        case 'w':
+          newState.up = false;
+          break;
+        case 's':
+          newState.down = false;
+          break;
+        case 'q':
+        case 'a':
+          newState.left = false;
+          break;
+        case 'd':
+          newState.right = false;
+          break;
+        case ' ':
+          newState.space = false;
+          break;
+      }
+      return newState;
+    });
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [handleKeyDown, handleKeyUp]);
+
+  return inputState;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,15 @@
-:root {
+body {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+}
+
+:root, #root {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,11 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.tsx'
+// import App from './App.tsx'
+import { Playground } from './features/john/Playground.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <Playground />
   </StrictMode>,
 )


### PR DESCRIPTION
- Ajout d'un repo "Engine" qui contient toute la logique métier - répartie en 
1. "Components": des "comportements" qu'on attache aux entitées 
2. "Systems": des systems qui utilisent les components et les orchestre pour implémenter la logique métier 

- Ajout d'une "Scene" Playground.tsx qui instancie un GO Player et un GO Enemy. 
- Ajout de composents React pour le Render basés sur une collection <clé,composants React> pour instancier le bon composant 

TODO : optimisations sur le render (memoize, et génération des composants React en amon, en mode Object Pooling?)  

![ecs](https://github.com/user-attachments/assets/8b75ecac-7c7e-40ac-b722-69cd67f081f6)
